### PR TITLE
fix needed for safari (RangeError: Invalid Date)

### DIFF
--- a/src/CognitoSyncDatasetMetadata.js
+++ b/src/CognitoSyncDatasetMetadata.js
@@ -40,7 +40,7 @@ AWS.CognitoSyncManager.DatasetMetadata = (function(){
 
         // Meta metadata.
         this.lastSyncCount = metadata.LastSyncCount || 0;
-        this.lastSyncDate = new Date(metadata.LastSyncDate) || new Date();
+        this.lastSyncDate = metadata.LastSyncDate ? new Date(metadata.LastSyncDate) : new Date();
 
         // Validate object.
         if (this.dataStorage < 0) { throw new RangeError('Storage size cannot be negative.'); }


### PR DESCRIPTION
I could not get this to work on safari till I made this change.  I kept getting `RangeError: Invalid Date` when I tried to go `cognitoSyncClient.openOrCreateDataset('MyDataset', function(err, dataset) {`

Note
```js
date = new Date(undefined) || new Date();
Invalid Date

date = undefined ? undefined : new Date();
Date 2015-02-08T01:30:22.012Z
```

now it works, and I'm syncing between all my browsers.