### PR TITLE
removed deprecated config.credential call

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ gathered from the previous step.
 AWS.config.region = 'us-east-1';
 
 AWS.config.credentials = new AWS.CognitoIdentityCredentials({
-    AccountId: 'YOUR AWS ACCOUNT ID',
     IdentityPoolId: 'YOUR IDENTITY POOL ID',
-    RoleArn: 'YOUR UNAUTHENTICATED ROLE ARN'
 });
 ```
 


### PR DESCRIPTION
Giving an Account Id and RoleArn when first initializing the credentials not only is deprecated, but returns an authentication error to the API user.