### PR TITLE
Fixed typo in function call name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ dataset.synchronize({
 
         // Or... use custom logic.
         // var newValue = conflicts[i].getRemoteRecord().getValue() + conflicts[i].getLocalRecord().getValue();
-        // resolved.push(conflicts[i].resovleWithValue(newValue);
+        // resolved.push(conflicts[i].resolveWithValue(newValue);
 
      }
 


### PR DESCRIPTION
There was a typo in one of the commented out function call names.  This PR fixes it, that's all.