### PR TITLE
Update readme. CognitoSyncManager doesn't work

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class. It will assume the credentials from the AWS SDK.
 ```javascript
 AWS.config.credentials.get(function() {
 
-    client = new AWS.CognitoSyncManager();
+    client = new AWS.CognitoSync();
 
     // YOUR CODE HERE
 


### PR DESCRIPTION
Getting TypeError: AWS.CognitoSyncManager is not a function.
`AWS.CognitoSync() ` returns the client successfully.