### PR TITLE
Add the DataStore to options of the CognitoSyncManager.

### DIFF
--- a/src/CognitoSyncManager.js
+++ b/src/CognitoSyncManager.js
@@ -43,7 +43,7 @@ if (AWS === undefined) {
         }
 
         // Initialize local store.
-        this.local = new AWS.CognitoSyncManager.LocalStorage({DataStore: AWS.CognitoSyncManager.StoreLocalStorage});
+        this.local = new AWS.CognitoSyncManager.LocalStorage({DataStore: options.DataStore ? options.DataStore : AWS.CognitoSyncManager.StoreLocalStorage});
 
         // Initialize remote store.
         this.remote = new AWS.CognitoSyncManager.RemoteStorage(this.identityPoolId, this.provider);


### PR DESCRIPTION
I want to use a customized Datastore for CognitoSync (like code below).
```
var cognitoSyncManager = new AWS.CognitoSyncManager({DataStore: ObscuredLocalStorage});
```

Please review this pull request. Thank you.