### PR TITLE
Allow credentials and region to be passed as options

### DIFF
--- a/src/CognitoSyncManager.js
+++ b/src/CognitoSyncManager.js
@@ -31,9 +31,9 @@ if (AWS === undefined) {
 
         var USER_AGENT = 'CognitoJavaScriptSDK/1';
 
-        this.provider = AWS.config.credentials;
+        this.provider = options.credentials || AWS.config.credentials;
         this.identityPoolId = this.provider.params.IdentityPoolId;
-        this.region = AWS.config.region;
+        this.region = options.region || AWS.config.region;
 
         // Setup logger.
         this.logger = options.log;


### PR DESCRIPTION
All most all other AWS SDK services support this feature. Since this is not provided in CognitoSyncManager, it becomes a problem, when we want to do concurrent API calls to multiple AWS regions with different sets of credentials.